### PR TITLE
[JENKINS-60926] Update to 4.2 version of Remoting.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /target/
+*.iml

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>3.42</version>
+    <version>4.0-beta-4</version>
     <relativePath />
   </parent>
 
@@ -29,7 +29,7 @@
   </licenses>
 
   <properties>
-    <jenkins.version>2.60.3</jenkins.version>
+    <jenkins.version>2.220-rc29287.ce735e959d1a</jenkins.version>
     <java.level>8</java.level>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>4.0-beta-4</version>
+    <version>3.42</version>
     <relativePath />
   </parent>
 
@@ -29,7 +29,7 @@
   </licenses>
 
   <properties>
-    <jenkins.version>2.220-rc29287.ce735e959d1a</jenkins.version>
+    <jenkins.version>2.60.3</jenkins.version>
     <java.level>8</java.level>
   </properties>
 

--- a/src/main/java/org/jenkinsci/modules/slave_installer/impl/InstallerGui.java
+++ b/src/main/java/org/jenkinsci/modules/slave_installer/impl/InstallerGui.java
@@ -151,14 +151,14 @@ public class InstallerGui extends MasterToSlaveCallable<Void,IOException> {
             Method getAgentName = engineClass.getMethod("getAgentName");
             Object result = getAgentName.invoke(engine);
             return result.toString();
-        } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
+        } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException ignored) {
             // try using the older field
         }
         try {
             Field slaveName = engineClass.getField("slaveName");
             Object result = slaveName.get(engine);
             return result.toString();
-        } catch (NoSuchFieldException | IllegalAccessException e) {
+        } catch (NoSuchFieldException | IllegalAccessException ignored) {
 
         }
         throw new MalformedURLException("Unable to determine agent name.");

--- a/src/main/java/org/jenkinsci/modules/slave_installer/impl/InstallerGui.java
+++ b/src/main/java/org/jenkinsci/modules/slave_installer/impl/InstallerGui.java
@@ -139,7 +139,7 @@ public class InstallerGui extends MasterToSlaveCallable<Void,IOException> {
     }
 
     protected URL getJnlpUrl() throws MalformedURLException {
-        return new URL(engine.getHudsonUrl(),"computer/"+ Util.rawEncode(engine.slaveName)+"/slave-agent.jnlp");
+        return new URL(engine.getHudsonUrl(),"computer/"+ Util.rawEncode(engine.getAgentName())+"/slave-agent.jnlp");
     }
 
     private static final long serialVersionUID = 1L;


### PR DESCRIPTION
See [JENKINS-60926](https://issues.jenkins-ci.org/browse/JENKINS-60926).

This corrects a minor regression introduced in Remoting 4.0 and Jenkins 2.217 (2020-01-23). A renaming broke agent Windows service installation. This restores the behavior.

Related to and needs to be connected with jenkinsci/jenkins#4476. We probably need to publish an incremental here first.