### PR TITLE
[JENKINS-64666] Document project url

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,6 +13,7 @@
   <packaging>jenkins-module</packaging>
   <name>Agent installer module</name>
   <description>Base abstraction for platform-specific Jenkins agent installer</description>
+  <url>https://github.com/${gitHubRepo}</url>
 
   <scm>
     <connection>scm:git:git://github.com/${gitHubRepo}.git</connection>


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
Document project's url to allow jenkins' own `/about` page build correct links.
This fixes [JENKINS-64666](https://issues.jenkins.io/browse/JENKINS-64666)


- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
